### PR TITLE
pass RUN_OPTS env to app command line (for --xmx)

### DIFF
--- a/root/etc/services.d/nzbhydra2/run
+++ b/root/etc/services.d/nzbhydra2/run
@@ -5,6 +5,8 @@ unset HOST_OS
 
 cd /app/hydra2 || exit
 
+IFS=" " read -r -a RUN_ARRAY <<< "$RUN_OPTS"
+
 exec \
 	s6-setuidgid abc /usr/bin/python nzbhydra2wrapper.py \
-	--nobrowser --datafolder /config
+	--nobrowser --datafolder /config "${RUN_ARRAY[@]}"


### PR DESCRIPTION
This is intended to contribute to closing issue #6 

Allow the user to specify a RUN_OPTS environment variable in a container such as:

RUN_OPTS: "--xmx 2048"

This increases the maximum heap size (in megabytes) from the default of 128M.
This appears to be a an issue for certain users:

https://www.reddit.com/r/usenet/comments/8e61j8/nzbhydra2_dying_in_docker_container_roughly_once/

The style of this change is intended to be consistent with other linuxserver images such as tvheadend.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

