### PR TITLE
Remove python 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,14 @@ RUN \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
-	curl \
+	jq \
 	unzip && \
  apt-get install --no-install-recommends -y \
-	openjdk-11-jre-headless \
-	python && \
+	openjdk-11-jre-headless && \
  echo "**** install hydra2 ****" && \
  if [ -z ${HYDRA2_RELEASE+x} ]; then \
 	HYDRA2_RELEASE=$(curl -sX GET "https://api.github.com/repos/theotherp/nzbhydra2/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+	| jq -r .tag_name); \
  fi && \
  HYDRA2_VER=${HYDRA2_RELEASE#v} && \
  curl -o \
@@ -30,10 +29,7 @@ RUN \
 	"https://github.com/theotherp/nzbhydra2/releases/download/v${HYDRA2_VER}/nzbhydra2-${HYDRA2_VER}-linux.zip" && \
  mkdir -p /app/hydra2 && \
  unzip /tmp/hydra2.zip -d /app/hydra2 && \
- curl -o \
- /app/hydra2/nzbhydra2wrapper.py -L \
-	"https://raw.githubusercontent.com/theotherp/nzbhydra2/master/other/wrapper/nzbhydra2wrapper.py" && \
- chmod +x /app/hydra2/nzbhydra2wrapper.py && \
+ chmod +x /app/hydra2/nzbhydra2 && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \
@@ -45,4 +41,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 5076
-VOLUME /config /downloads
+VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,15 +14,14 @@ RUN \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
-	curl \
+	jq \
 	unzip && \
  apt-get install --no-install-recommends -y \
-	openjdk-11-jre-headless \
-	python && \
+	openjdk-11-jre-headless && \
  echo "**** install hydra2 ****" && \
  if [ -z ${HYDRA2_RELEASE+x} ]; then \
 	HYDRA2_RELEASE=$(curl -sX GET "https://api.github.com/repos/theotherp/nzbhydra2/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+	| jq -r .tag_name); \
  fi && \
  HYDRA2_VER=${HYDRA2_RELEASE#v} && \
  curl -o \
@@ -30,10 +29,7 @@ RUN \
 	"https://github.com/theotherp/nzbhydra2/releases/download/v${HYDRA2_VER}/nzbhydra2-${HYDRA2_VER}-linux.zip" && \
  mkdir -p /app/hydra2 && \
  unzip /tmp/hydra2.zip -d /app/hydra2 && \
- curl -o \
- /app/hydra2/nzbhydra2wrapper.py -L \
-	"https://raw.githubusercontent.com/theotherp/nzbhydra2/master/other/wrapper/nzbhydra2wrapper.py" && \
- chmod +x /app/hydra2/nzbhydra2wrapper.py && \
+ chmod +x /app/hydra2/nzbhydra2 && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \
@@ -45,4 +41,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 5076
-VOLUME /config /downloads
+VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,15 +14,14 @@ RUN \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
-	curl \
+	jq \
 	unzip && \
  apt-get install --no-install-recommends -y \
-	openjdk-11-jre-headless \
-	python && \
+	openjdk-11-jre-headless && \
  echo "**** install hydra2 ****" && \
  if [ -z ${HYDRA2_RELEASE+x} ]; then \
 	HYDRA2_RELEASE=$(curl -sX GET "https://api.github.com/repos/theotherp/nzbhydra2/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
+	| jq -r .tag_name); \
  fi && \
  HYDRA2_VER=${HYDRA2_RELEASE#v} && \
  curl -o \
@@ -30,10 +29,7 @@ RUN \
 	"https://github.com/theotherp/nzbhydra2/releases/download/v${HYDRA2_VER}/nzbhydra2-${HYDRA2_VER}-linux.zip" && \
  mkdir -p /app/hydra2 && \
  unzip /tmp/hydra2.zip -d /app/hydra2 && \
- curl -o \
- /app/hydra2/nzbhydra2wrapper.py -L \
-	"https://raw.githubusercontent.com/theotherp/nzbhydra2/master/other/wrapper/nzbhydra2wrapper.py" && \
- chmod +x /app/hydra2/nzbhydra2wrapper.py && \
+ chmod +x /app/hydra2/nzbhydra2 && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \
@@ -45,4 +41,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 5076
-VOLUME /config /downloads
+VOLUME /config

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -53,6 +53,7 @@ app_setup_block: |
 # changelog
 
 changelogs:
+  - { date: "01.01.20:", desc: "Remove python and run directly using Java." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "11.02.19:", desc: "Add pipeline logic and multi arch." }
   - { date: "18.08.18:", desc: "Bump java version to 10, (bionic currently refers to it as version 11)." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -5,5 +5,4 @@ mkdir -p /config/logs
 
 
 # permissions
-chmod +x /app/hydra2/nzbhydra2
 chown -R abc:abc /config

--- a/root/etc/services.d/nzbhydra2/run
+++ b/root/etc/services.d/nzbhydra2/run
@@ -6,5 +6,5 @@ unset HOST_OS
 cd /app/hydra2 || exit
 
 exec \
-	s6-setuidgid abc /usr/bin/python nzbhydra2wrapper.py \
+	s6-setuidgid abc /app/hydra2/nzbhydra2 \
 	--nobrowser --datafolder /config


### PR DESCRIPTION
Hydra2 only used python as a wrapper to run, but it can be run without the wrapper directly using Java.

I've also included some other small cleanups like using jq to simplify reading the release version and remove the `/downloads` volume, 